### PR TITLE
[Feature Request #6] Add UI and functionality for DR icons to be specified

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -26,6 +26,16 @@ local drCategories = {
     ["Silence"] = "Silences",
     ["Root"] = "Roots",
 }
+
+local drIcons = {
+    Stun = 132298,
+    Incapacitate = 136071,
+    Disorient = 136183,
+    Silence = 458230,
+    Root = 136100,
+}
+
+
 local racialCategories = {
     ["Human"] = "Human",
     ["Scourge"] = "Undead",
@@ -628,6 +638,27 @@ function sArenaMixin:UpdateRacialSettings(db, info, val)
     end
 end
 
+local function setDRIcons()
+    local drIconsOrder = {"Stun", "Incapacitate", "Disorient", "Silence", "Root"}
+    local inputs = {
+        drIconsTitle = {
+            order = 1,
+            type = "description",
+            name = "Configure DR Icons",
+            fontSize = "medium",
+        }
+    }
+    for index, drName in ipairs(drIconsOrder) do
+        inputs[drName] = {
+            order = index + 1,
+            name = drName .. ":",
+            type = "input",
+            width = "full",
+        }
+    end
+    return inputs
+end
+
 sArenaMixin.optionsTable = {
     type = "group",
     childGroups = "tab",
@@ -760,7 +791,28 @@ sArenaMixin.optionsTable = {
                             desc = "DR icons will show which spell triggered the DR",
                             type = "toggle",
                             get = function(info) return info.handler.db.profile.drDynamicIcons end,
-                            set = function(info, val) info.handler.db.profile.drDynamicIcons = val end,
+                            set = function(info, val)
+                                info.handler.db.profile.drDynamicIcons = val
+                                -- Force a refresh of the options
+                                LibStub("AceConfigRegistry-3.0"):NotifyChange("sArena")
+                            end,
+                        },
+                        drIconsSection = {
+                            order = 3,
+                            type = "group",
+                            name = "DR Icons Settings",
+                            inline = true,
+                            disabled = function(info) return info.handler.db.profile.drDynamicIcons end,
+                            get = function(info)
+                                local key = info[#info]
+                                return tostring(info.handler.db.profile.drIcons[key] or drIcons[key])
+                            end,
+                            set = function(info, value)
+                                local key = info[#info]
+                                local num = tonumber(value)
+                                info.handler.db.profile.drIcons[key] = num or value
+                            end,
+                            args = setDRIcons(),
                         },
                     },
                 },

--- a/Modules/DiminishingReturns.lua
+++ b/Modules/DiminishingReturns.lua
@@ -24,7 +24,7 @@ local severityColor = {
     [3] = { 1, 0, 0, 1},
 }
 
-local drIcons = {
+sArenaMixin.defaultSettings.profile.drIcons = {
     Stun = 132298,
     Incapacitate = 136071,
     Disorient = 136183,
@@ -72,7 +72,7 @@ function sArenaFrameMixin:FindDR(combatEvent, spellID)
         end
     end
 
-    frame.Icon:SetTexture(self.parent.db.profile.drDynamicIcons and C_Spell.GetSpellTexture(spellID) or drIcons[category])
+    frame.Icon:SetTexture(self.parent.db.profile.drDynamicIcons and C_Spell.GetSpellTexture(spellID) or self.parent.db.profile.drIcons[category])
     frame.Border:SetVertexColor(unpack(severityColor[frame.severity]))
 
     frame.severity = frame.severity + 1


### PR DESCRIPTION
Allow DR icons to be specified ingame and save the selected DR icon choice.
Could be modified to use Spellname or SpellID, but will go with iconID for now that can be found on: https://www.wowhead.com/icons

Tested on TWW beta, but please feel free to test it to check for any issues.

![image](https://github.com/user-attachments/assets/fd6ffd6b-2688-403d-8b68-f933fb3d8851)
