### PR TITLE
Will to Survive and Gladiator’s Medallion now share a 60 second cooldown for healer specializations

### DIFF
--- a/Modules/Racials.lua
+++ b/Modules/Racials.lua
@@ -110,7 +110,13 @@ function sArenaFrameMixin:FindRacial(event, spellID)
             local remainingCD = GetRemainingCD(self.Trinket.Cooldown)
             local sharedCD = racialData[self.race].sharedCD
 
-            if ( sharedCD and remainingCD < sharedCD ) then
+            -- Check if the unit is a healer and if the race is Human and trinket is Medallion
+            if ( self.race == "Human" and IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+                sharedCD = 60  -- Set sharedCD to 60
+            end
+
+            -- Apply the shared cooldown if remaining time is less than the sharedCD
+            if (sharedCD and remainingCD < sharedCD) then
                 self.Trinket.Cooldown:SetCooldown(currTime, sharedCD)
             end
         end
@@ -118,7 +124,13 @@ function sArenaFrameMixin:FindRacial(event, spellID)
         local remainingCD = GetRemainingCD(self.Racial.Cooldown)
         local sharedCD = racialData[self.race].sharedCD
 
-        if ( sharedCD and remainingCD < sharedCD ) then
+        -- Check if the unit is a healer and if the race is Human and trinket is Medallion
+        if ( self.race == "Human" and IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+            sharedCD = 60  -- Set sharedCD to 60 if the unit is a healer
+        end
+
+        -- Apply the shared cooldown if remaining time is less than the sharedCD
+        if (sharedCD and remainingCD < sharedCD) then
             self.Racial.Cooldown:SetCooldown(GetTime(), sharedCD)
         end
     end

--- a/Modules/Racials.lua
+++ b/Modules/Racials.lua
@@ -111,7 +111,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
             local sharedCD = racialData[self.race].sharedCD
 
             -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-            if ( self.race == "Human" and self:IsHealer(unit) and self.Trinket.spellID == 336126 ) then
+            if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
                 sharedCD = 60  -- Set sharedCD to 60
             end
 
@@ -125,7 +125,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
         local sharedCD = racialData[self.race].sharedCD
 
         -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-        if ( self.race == "Human" and self:IsHealer(unit) and self.Trinket.spellID == 336126 ) then
+        if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
             sharedCD = 60  -- Set sharedCD to 60 if the unit is a healer
         end
 

--- a/Modules/Racials.lua
+++ b/Modules/Racials.lua
@@ -111,7 +111,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
             local sharedCD = racialData[self.race].sharedCD
 
             -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-            if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+            if ( self.race == "Human" and self:IsHealer(unit) and self.Trinket.spellID == 336126 ) then
                 sharedCD = 60  -- Set sharedCD to 60
             end
 
@@ -125,7 +125,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
         local sharedCD = racialData[self.race].sharedCD
 
         -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-        if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+        if ( self.race == "Human" and self:IsHealer(unit) and self.Trinket.spellID == 336126 ) then
             sharedCD = 60  -- Set sharedCD to 60 if the unit is a healer
         end
 

--- a/Modules/Racials.lua
+++ b/Modules/Racials.lua
@@ -111,7 +111,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
             local sharedCD = racialData[self.race].sharedCD
 
             -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-            if ( self.race == "Human" and IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+            if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
                 sharedCD = 60  -- Set sharedCD to 60
             end
 
@@ -125,7 +125,7 @@ function sArenaFrameMixin:FindRacial(event, spellID)
         local sharedCD = racialData[self.race].sharedCD
 
         -- Check if the unit is a healer and if the race is Human and trinket is Medallion
-        if ( self.race == "Human" and IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
+        if ( self.race == "Human" and self:IsHealer(self.unit) and self.Trinket.spellID == 336126 ) then
             sharedCD = 60  -- Set sharedCD to 60 if the unit is a healer
         end
 

--- a/sArena.lua
+++ b/sArena.lua
@@ -785,7 +785,7 @@ function sArenaFrameMixin:UpdateClassIcon()
     self.ClassIcon:SetTexture(texture)
 end
 
-function IsHealer(unit)
+function sArenaFrameMixin:IsHealer(unit)
 	local id = string.match(unit, "arena(%d)")
 	local specID = GetArenaOpponentSpec and GetArenaOpponentSpec(id)
 	if(specID) then
@@ -811,7 +811,7 @@ function sArenaFrameMixin:UpdateTrinketSammers(unit, spellId)
     -- Normal Trinket
     if (spellId == 336126) then
         trinket.Cooldown:SetCooldown(GetTime(), 120)
-        if (IsHealer(unit)) then
+        if (self:IsHealer(unit)) then
             trinket.Cooldown:SetCooldown(GetTime(), 90)
         end
         -- Dwarf Racial 20594(normal) and 265221(iron dwarf)

--- a/sArena.lua
+++ b/sArena.lua
@@ -785,7 +785,7 @@ function sArenaFrameMixin:UpdateClassIcon()
     self.ClassIcon:SetTexture(texture)
 end
 
-local function IsHealer(unit)
+function IsHealer(unit)
 	local id = string.match(unit, "arena(%d)")
 	local specID = GetArenaOpponentSpec and GetArenaOpponentSpec(id)
 	if(specID) then


### PR DESCRIPTION
March 11 PvP changes:
Player versus Player
Will to Survive and Gladiator’s Medallion now share a 60 second cooldown for healer specializations (was 90 seconds).

I have not had a chance to test this, but simply putting the PR in for awareness too.

